### PR TITLE
Add missing declaration to fix compilation error.

### DIFF
--- a/interface/src/interface.c
+++ b/interface/src/interface.c
@@ -427,7 +427,7 @@ void interface_sleep_ms (uint32_t val)
   interface_time_ms
 
 ===========================================================================*/
-uint32_t interface_time_ms ()
+uint32_t interface_time_ms (uint32_t val)
   {
 #if PICO_ON_DEVICE
   return to_ms_since_boot(get_absolute_time());


### PR DESCRIPTION
Compiler complained about `val` being undeclared in this block.  Adding the declaration eliminated the compilation error and `luapico` appears to build and run correctly on both the host and Pico hardware now.